### PR TITLE
Added Fortran 95 standard and written FORTRAN 77 uppercase

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -5,7 +5,8 @@ Quick links:
 
     * Summary of the language: http://www.cs.umbc.edu/~squire/fortranclass/summary.shtml
     * Language featues: http://en.wikipedia.org/wiki/Fortran_language_features
-    * Fortran 77 standard: http://www.fortran.com/F77_std/rjcnf0001.html
+    * FORTRAN 77 standard: http://www.fortran.com/F77_std/rjcnf0001.html
+    * Fortran 95 standard: http://j3-fortran.org/doc/standing/archive/007/97-007r2/pdf/97-007r2.pdf
     * Fortran 2003 standard: http://www.j3-fortran.org/doc/year/04/04-007.pdf
     * Fortran 2008 standard: ftp://ftp.nag.co.uk/sc22wg5/N1801-N1850/N1830.pdf
 


### PR DESCRIPTION
I added a link at the front page to the Fortran 95 standard (extracted from http://gcc.gnu.org/wiki/GFortranStandards#Fortran_2003) and also wrote FORTRAN 77 all in uppercase, as that is the way it is referred along the standard. I don't consider it's neccesary to add the Fortran 90 standard, as the added one just updates it and makes some features obsolete.
