### PR TITLE
Fix a datatype declaration

### DIFF
--- a/src/best-practices.rst
+++ b/src/best-practices.rst
@@ -579,7 +579,7 @@ this Cython code:
                 double *mesh)
 
     def mesh_exp(double r_min, double r_max, double a, int N):
-        cdef ndarray[double, mode="c"] mesh = empty(N, dtype="double")
+        cdef ndarray[double, mode="c"] mesh = empty(N, dtype=double)
         c_mesh_exp(&r_min, &r_max, &a, &N, &mesh[0])
         return mesh
 


### PR DESCRIPTION
Cython does not use strings for the dtype attribute of ndarrays
in declarations.
