### PR TITLE
Specify n quantum number example in FAQ

### DIFF
--- a/src/faq.rst
+++ b/src/faq.rst
@@ -186,7 +186,7 @@ Let's look at a few examples:
 
 * You say "I finished first", not "I finished zeroth"
 
-* The ``n`` quantum number is typically from 1 to ``n_max``.
+* In atomic physics, the ``n`` quantum number is from 1 to ``n_max``.
 
 * The angular momentum quantum number ``l`` is from ``0`` to ``n-1``
 


### PR DESCRIPTION
For typical atomic physics problems the n quantum number is in [1,
n_max]. For another landmark quantum problem, the harmonic oscillator, n
starts from 0.

This takes some "bang" out of the example, but reading through the FAQ, that n
thing felt fishy to me (probably because I'm more a harmonic oscillator physicist 
than an atom guy?).
