### PR TITLE
Add Emacs command for automatic free-form indentation

### DIFF
--- a/src/faq.rst
+++ b/src/faq.rst
@@ -409,3 +409,10 @@ For Intel ifort::
 
     -warn all -fast
 
+How do I indent free-form Fortran source code in a consistent manner automatically?
+-----------------------------------------------------------------------------------
+
+If your editor or IDE does not support automatic indentation, you may want to
+use Emacs' batch mode instead::
+
+     emacs --batch filename.f90 -f mark-whole-buffer -f f90-indent-subprogram -f save-buffer


### PR DESCRIPTION
Consistent indentation is important for projects with several contributors. As typically different editors and IDEs are used on the same project, it is desirable to get consistent indentation by an automated procedure. I've added the Emacs command I use for this purpose.

@certik, maybe you can add something similar for vi?
