### PR TITLE
Updates a few reference URLs

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -4,11 +4,11 @@ Fortran 90
 Quick links:
 
     * Summary of the language: http://www.cs.umbc.edu/~squire/fortranclass/summary.shtml
-    * Language features: http://en.wikipedia.org/wiki/Fortran_language_features
+    * Language features: http://en.wikipedia.org/wiki/Fortran_95_language_features
     * FORTRAN 77 standard: http://www.fortran.com/F77_std/rjcnf0001.html
     * Fortran 95 standard: http://j3-fortran.org/doc/standing/archive/007/97-007r2/pdf/97-007r2.pdf
     * Fortran 2003 standard: http://www.j3-fortran.org/doc/year/04/04-007.pdf
-    * Fortran 2008 standard: ftp://ftp.nag.co.uk/sc22wg5/N1801-N1850/N1830.pdf
+    * Fortran 2008 standard: http://www.j3-fortran.org/doc/year/10/10-007.pdf
 
 Contents:
 


### PR DESCRIPTION
Previous Wikipedia URL gets redirected to suggested updated URL

Previous Fortran 2008 standard URL is a dead link. Suggested URL retrieved from https://gcc.gnu.org/wiki/GFortranStandards#Fortran_2008