### PR TITLE
Fixes non-standard array indexing typo

### DIFF
--- a/src/rosetta.rst
+++ b/src/rosetta.rst
@@ -237,7 +237,7 @@ First `n` elements:
 |::                                                    |.. code-block:: fortran                                 |
 |                                                      |                                                        |
 | a[:n]                                                | a(:n)     ! assuming starting index 1 (default)        |
-|                                                      | a(:n-m+1) ! assuming starting index m                  |
+|                                                      | a(:n+m-1) ! assuming starting index m                  |
 +------------------------------------------------------+--------------------------------------------------------+
 
 Last `n` elements:


### PR DESCRIPTION
Minor typo breaks the indexing into the Fortran array