### PR TITLE
ENH: omitting a dot demotes a literal to an integer

### DIFF
--- a/src/best-practices.rst
+++ b/src/best-practices.rst
@@ -83,6 +83,7 @@ Always write all floating point constants with the ``_dp`` suffix::
 
 and never any other way (see also the gotcha
 :ref:`floating_point_numbers_gotcha`).
+Omitting the dot in the literal constant is also incorrect.
 
 To print floating point double precision
 numbers without losing precision, use the ``(es23.16)`` format (see

--- a/src/gotchas.rst
+++ b/src/gotchas.rst
@@ -61,6 +61,13 @@ And so it is safe to assign integers to floating point numbers without losing
 any accuracy (but one must be careful about integer division, e.g.  ``1/2`` is
 equal to ``0`` and not ``0.5``).
 
+The declaration of integer variables with a ``_dp`` suffix does not promote them
+automatically to double precision variables. The following literal::
+
+    360_dp
+
+is interpreted as an integer.
+
 C/Fortran Interoperability of Logical
 -------------------------------------
 


### PR DESCRIPTION
Resolves #19