### PR TITLE
Using explicit shape for output when shape of input known.

### DIFF
--- a/src/best-practices.rst
+++ b/src/best-practices.rst
@@ -418,7 +418,7 @@ Or one can use `explicit-shape` arrays as follows::
     function nroot(n, k, x) result(y)
     integer, intent(in) :: n, k
     real(dp), intent(in) :: x(k)
-    real(dp) :: y(size(x))
+    real(dp) :: y(k)
     y = x**(1._dp / n)
     end function
 


### PR DESCRIPTION
@certik I'm not sure if you had declared the size of `y` based on `x` on purpose, or just from copy-pasta from the assumed shape example in the same section (seems this content has been untouched since 2012 according to `git blame`)