### PR TITLE
Declare `lam` as an array

### DIFF
--- a/src/best-practices.rst
+++ b/src/best-practices.rst
@@ -444,7 +444,7 @@ memory automatically and it is not possible to create memory leaks.
 For example you can allocate it inside a subroutine::
 
     subroutine foo(lam)
-    real(dp), allocatable, intent(out) :: lam
+    real(dp), allocatable, intent(out) :: lam(:)
     allocate(lam(5))
     end subroutine
 

--- a/src/best-practices.rst
+++ b/src/best-practices.rst
@@ -450,7 +450,7 @@ For example you can allocate it inside a subroutine::
 
 And use somewhere else::
 
-    real(dp), allocatable :: lam
+    real(dp), allocatable :: lam(:)
     call foo(lam)
 
 When the ``lam`` symbol goes out of scope, Fortran will deallocate it. If


### PR DESCRIPTION
Fixes #44.