### PR TITLE
latexpdf: workaround for undefined '<=' unicode character

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -178,7 +178,7 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-#'preamble': '',
+  'preamble': '\DeclareUnicodeCharacter{2264}{$\leq$}'
 }
 
 # Grouping the document tree into LaTeX files. List of tuples


### PR DESCRIPTION
building latexpdf fails with: ! LaTeX Error: Unicode character ≤ (U+2264) not set up for use with LaTeX

there is no \leq for text mode, using \leq from math mode is not pretty but works

Fixes #51 